### PR TITLE
Fix: OAuth Client ID availability at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,9 @@ RUN corepack enable && corepack prepare pnpm@latest --activate && pnpm install -
 
 COPY . .
 
-# Accept build-time env vars for Next.js (NEXT_PUBLIC_ vars are inlined at build)
-ARG NEXT_PUBLIC_GITHUB_CLIENT_ID
-ENV NEXT_PUBLIC_GITHUB_CLIENT_ID=$NEXT_PUBLIC_GITHUB_CLIENT_ID
-
 # Build the Next.js app
-RUN pnpm build
+# Source .env if present so NEXT_PUBLIC_* vars are inlined at build time
+RUN if [ -f .env ]; then export $(cat .env | xargs) 2>/dev/null; fi && pnpm build
 
 EXPOSE 3000
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   transpilePackages: ["react-markdown", "remark-gfm", "rehype-raw"],
+  env: {
+    NEXT_PUBLIC_GITHUB_CLIENT_ID: process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID ?? "",
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Ensures NEXT_PUBLIC_GITHUB_CLIENT_ID is available when Next.js builds inside Docker during Blaxel deployment. Updates Dockerfile to source .env during build and adds env override in next.config.ts so the OAuth device flow login appears instead of PAT input on the deployed dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)