### PR TITLE
Approve build scripts to fix pnpm install in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -41,5 +41,13 @@
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.0.18"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "msw",
+      "sharp",
+      "unrs-resolver"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Add `pnpm.onlyBuiltDependencies` to `package.json` allowlisting `esbuild`, `msw`, `sharp`, and `unrs-resolver`.
- Fixes CI failure on `pnpm install --frozen-lockfile` where pnpm 10 exits non-zero with `ERR_PNPM_IGNORED_BUILDS` unless postinstall scripts are explicitly approved.

## Test plan
- [ ] CI passes on this PR