### PR TITLE
Pin pnpm to v10 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY --from=ghcr.io/blaxel-ai/sandbox:latest /sandbox-api /usr/local/bin/sandbox
 
 # Copy project files and install dependencies
 COPY package.json pnpm-lock.yaml ./
-RUN corepack enable && corepack prepare pnpm@latest --activate && pnpm install --frozen-lockfile
+RUN corepack enable && corepack prepare pnpm@10 --activate && pnpm install --frozen-lockfile
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- Pin pnpm to v10 in the Dockerfile, matching the CI/deploy workflows already pinned in #16.
- pnpm 11 dropped reading the `"pnpm"` field from `package.json`, so `onlyBuiltDependencies` was ignored and Docker builds failed with `ERR_PNPM_IGNORED_BUILDS` on esbuild/msw/sharp/unrs-resolver.

## Test plan
- [ ] Docker build succeeds (`pnpm install --frozen-lockfile` completes without `ERR_PNPM_IGNORED_BUILDS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)